### PR TITLE
ignore transparent and inherit values

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     "stylelint-order"
   ],
   rules: {
-    "sh-waqar/declaration-use-variable": "/color/",
+    "sh-waqar/declaration-use-variable": [ [ "/color/", { ignoreValues: ["transparent", "inherit"] } ] ],
     "order/properties-alphabetical-order": true,
     "function-url-quotes": "always",
     "selector-class-pattern": null,


### PR DESCRIPTION
Used stylelint in project and it errored when trying to set `background-color: transparent;`

Copied from https://github.com/sh-waqar/stylelint-declaration-use-variable#options