### PR TITLE
Prevent missing & from nesting selectors with PostCSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,5 +12,6 @@ module.exports = {
     "function-url-quotes": "always",
     "selector-class-pattern": null,
     "no-eol-whitespace": null
+    "selector-nested-pattern": ["^&"]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/stylelint-config",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/stylelint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "10up stylelint config for WordPress projects",
   "main": "index.js",
   "homepage": "https://github.com/10up/stylelint-config#readme",


### PR DESCRIPTION
Fixes #9 

A common issue when coming from Sass writing is to forget the required `&` when nesting _all_ selectors in PostCSS.

Also, there is no means to know this without some linting. I was recently on a project where a single missing nested `&` caused a few hours worth of debugging, which was causing several major bugs.

Let's prevent this with linting! 😄 

With the addition of this code. This code sample: 

```
body {
	background-color: var(--THEME-COLOR-DARK);
}

body > * {
	background-color: var(--THEME-COLOR-LIGHT);
	margin-left: auto;
	margin-right: auto;
	max-width: var(--THEME-MAX-WIDTH-FULL);
	width: 100%;

	& .test {
		padding-left: 2px;

		&:hover {
			padding: 7px;
		}
	}

	&:not(.bother),
	&:hover(.other) {
		padding: 7px;
	}

	& .bothering:not(.test) {
		margin: 10px;
	}

	.test-2 {
		margin-left: 2px;
	}
}
```

Throws the following error: ` 29:2   ✖  Expected nested selector ".test-2" to match specified pattern   selector-nested-pattern `

Further reading: https://github.com/stylelint/stylelint/issues/2269