### PR TITLE
Fix missing comma in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     "order/properties-alphabetical-order": true,
     "function-url-quotes": "always",
     "selector-class-pattern": null,
-    "no-eol-whitespace": null
+    "no-eol-whitespace": null,
     "selector-nested-pattern": ["^&"]
   }
 };


### PR DESCRIPTION
### Description of the Change
Fixes missing comma in index.js that was causing syntax error when running 'npm run watch' in plugin scaffold after upgrading to@10up/stylelint-config v1.0.4


### Alternate Designs

N/A

### Benefits

No longer receive  SyntaxError

### Possible Drawbacks

N/A

### Verification Process

Changed local node_module, SyntaxError no longer thrown, functions as expected.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
