### PR TITLE
add currentColor to ignoreValues

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     "stylelint-order"
   ],
   rules: {
-    "sh-waqar/declaration-use-variable": [ [ "/color/", { ignoreValues: ["transparent", "inherit"] } ] ],
+    "sh-waqar/declaration-use-variable": [ [ "/color/", { ignoreValues: ["transparent", "inherit", "currentColor"] } ] ],
     "order/properties-alphabetical-order": true,
     "function-url-quotes": "always",
     "selector-class-pattern": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/stylelint-config",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/stylelint-config",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "10up stylelint config for WordPress projects",
   "main": "index.js",
   "homepage": "https://github.com/10up/stylelint-config#readme",


### PR DESCRIPTION
Fixes #11 

### Description of the Change

add `currentColor` property to list of `ignoreValues` for the [`sh-waqar/declaration-use-variable`](https://github.com/sh-waqar/stylelint-declaration-use-variable#options)

### Benefits

Allows engineers to use [`currentColor`](https://css-tricks.com/currentcolor/) for things like SVGs.

### Possible Drawbacks

None that I'm aware of.

### Verification Process

Used it for an entire build and worked great!

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
