### PR TITLE
Remove no descending specificity rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,5 @@ module.exports = {
     "selector-class-pattern": null,
     "no-eol-whitespace": null,
     "selector-nested-pattern": ["^&"],
-    "no-descending-specificity": [true, { "severity": "warning" }],
   }
 };


### PR DESCRIPTION
### Description of the Change

This PR removes the `no-descending-specificity` rule from the config. This rule flags false positives that use nesting with PostCSS.

### Benefits

Tailors our config to work better with PostCSS which is being used in most (if not all) new projects.

### Possible Drawbacks

This rule could be working fine in certain projects.


### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

- Removed rule `no-descending-specificity` from config to prevent false positives when nesting with PostCSS.