### PR TITLE
Disable No Descending Specificity Rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,5 +13,6 @@ module.exports = {
     "selector-class-pattern": null,
     "no-eol-whitespace": null,
     "selector-nested-pattern": ["^&"],
+    "no-descending-specificity": null,
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10up/stylelint-config",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "10up stylelint config for WordPress projects",
   "main": "index.js",
   "homepage": "https://github.com/10up/stylelint-config#readme",


### PR DESCRIPTION
### Description of the Change

Disabling `no-descending-specificity`. Turns out this rule is turned on in the stylelint-recommended which the wordpress config inherits, which our config then inherits. *takes breath*

This should fix that.

### Benefits

Will prevent false positives from using nesting in PostCSS

### Checklist:

- [x] My code follows the code style of this project.

### Changelog Entry

- patch to disable `no-descending-specificity` rule.
